### PR TITLE
Fix configured

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_URL', 'http://students.cs.uri.edu/~ben/selfauth/');
-define('APP_KEY', '2c2f87d0d894481ab56feea402cfb565');
-define('USER_HASH', '2c74e9031b927396ca24b1d7a8ed86b1');
-define('USER_URL', 'http://students.cs.uri.edu/~ben');
+define('APP_URL', '');
+define('APP_KEY', '');
+define('USER_HASH', '');
+define('USER_URL', '');

--- a/setup.php
+++ b/setup.php
@@ -52,7 +52,7 @@ define('USER_URL', '$user');";
 
 	$file_written = false;
 
-    if(is_writeable($configfile) && !$configured()){
+    if(is_writeable($configfile) && !$configured){
 
 		$handle = fopen($configfile, 'w');
 


### PR DESCRIPTION
See https://chat.indieweb.org/2017-06-23#t1498208750118000

Fixes a weird bug where `$configured()` was called.

Also restores the `config.php` back to empty strings.