### PR TITLE
Input data validation and overall refactoring.

### DIFF
--- a/index.php
+++ b/index.php
@@ -250,13 +250,14 @@ if ($pass_input !== null) {
     } else {
         $final_redir .= '&';
     }
-    $final_redir .= http_build_query(
-        array(
-            'code' => $code,
-            'state' => $state,
-            'me' => $me
-        )
+    $parameters = array(
+        'code' => $code,
+        'me' => $me
     );
+    if ($state !== null) {
+        $parameters['state'] = $state;
+    }
+    $final_redir .= http_build_query($parameters);
 
     // Redirect back.
     header('Location: ' . $final_redir, true, 302);

--- a/index.php
+++ b/index.php
@@ -3,7 +3,9 @@ function error_page($header, $body, $http = '400 Bad Request')
 {
     $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
     header($protocol . ' ' . $http);
-    die("<html>
+    $html = <<<HTML
+<!doctype html>
+<html>
     <head>
         <style>
             .error{
@@ -20,14 +22,19 @@ function error_page($header, $body, $http = '400 Bad Request')
             <p>$body</p>
         </div>
     </body>
-</html>");
+</html>
+HTML;
+    die($html);
 }
 
 $configfile= __DIR__ . '/config.php';
-if(file_exists($configfile)){
-    require_once $configfile;
+if (file_exists($configfile)) {
+    include_once $configfile;
 } else {
-    error_page('Configuration Error', 'Endpoint not yet configured, visit <a href="setup.php">setup.php</a> for instructions on how to set it up.');
+    error_page(
+        'Configuration Error',
+        'Endpoint not yet configured, visit <a href="setup.php">setup.php</a> for instructions on how to set it up.'
+    );
 }
 
 // Signed codes always have an time-to-live, by default 1 year (31536000 seconds).
@@ -42,9 +49,13 @@ function create_signed_code($key, $message, $ttl = 31536000, $appended_data = ''
 function verify_signed_code($key, $message, $code)
 {
     $code_parts = explode(':', $code, 3);
-    if (count($code_parts) !== 3) return false;
+    if (count($code_parts) !== 3) {
+        return false;
+    }
     $expires = hexdec($code_parts[0]);
-    if (time() > $expires) return false;
+    if (time() > $expires) {
+        return false;
+    }
     $body = $message . $expires . $code_parts[2];
     $signature = hash_hmac('sha256', $body, $key);
     if (function_exists('hash_equals')) {
@@ -65,24 +76,42 @@ function verify_password($url, $pass)
     return ($input_user == $configured_user && $hash == USER_HASH);
 }
 
-if((!defined('APP_URL') || APP_URL == '')
+function filter_input_regexp($type, $variable, $regexp)
+{
+    return filter_input(
+        $type,
+        $variable,
+        FILTER_VALIDATE_REGEXP,
+        array(
+            'options' => array('regexp' => $regexp)
+        )
+    );
+}
+
+if ((!defined('APP_URL') || APP_URL == '')
     || (!defined('APP_KEY') || APP_KEY == '')
     || (!defined('USER_HASH') || USER_HASH == '')
     || (!defined('USER_URL') || USER_URL == '')
 ) {
-    error_page('Configuration Error', 'Endpoint not configured correctly, visit <a href="setup.php">setup.php</a> for instructions on how to set it up.');
+    error_page(
+        'Configuration Error',
+        'Endpoint not configured correctly, visit <a href="setup.php">setup.php</a> for instructions on how to set it up.'
+    );
 }
 
 // First handle verification of codes.
-$code = filter_input(INPUT_POST, 'code', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '@^[0-9a-f]+:[0-9a-f]{64}:@')));
+$code = filter_input_regexp(INPUT_POST, 'code', '@^[0-9a-f]+:[0-9a-f]{64}:@');
 
 if ($code !== null) {
-
-    $redirect_uri = filter_input(INPUT_POST, 'redirect_uri', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
-    $client_id = filter_input(INPUT_POST, 'client_id', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
+    $redirect_uri = filter_input(INPUT_POST, 'redirect_uri', FILTER_VALIDATE_URL);
+    $client_id = filter_input(INPUT_POST, 'client_id', FILTER_VALIDATE_URL);
 
     // Exit if there are errors in the client supplied data.
-    if (!(is_string($code) && is_string($redirect_uri) && is_string($client_id) && verify_signed_code(APP_KEY, USER_URL . $redirect_uri . $client_id, $code))) {
+    if (!(is_string($code)
+        && is_string($redirect_uri)
+        && is_string($client_id)
+        && verify_signed_code(APP_KEY, USER_URL . $redirect_uri . $client_id, $code))
+    ) {
         error_page('Verification Failed', 'Given Code Was Invalid');
     }
 
@@ -117,7 +146,11 @@ if ($code !== null) {
 
     // Respond in the correct way.
     if ($json === 0 && $form === 0) {
-        error_page('No Accepted Response Types', 'The client accepts neither JSON nor Form encoded responses.', '406 Not Acceptable');
+        error_page(
+            'No Accepted Response Types',
+            'The client accepts neither JSON nor Form encoded responses.',
+            '406 Not Acceptable'
+        );
     } elseif ($json >= $form) {
         header('Content-Type: application/json');
         exit(json_encode(array('me' => USER_URL)));
@@ -129,30 +162,48 @@ if ($code !== null) {
 
 // If this is not verification, collect all the client supplied data. Exit on errors.
 
-$me = filter_input(INPUT_GET, 'me', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
-$client_id = filter_input(INPUT_GET, 'client_id', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
-$redirect_uri = filter_input(INPUT_GET, 'redirect_uri', FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
-$state = filter_input(INPUT_GET, 'state', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '@^[\x20-\x7E]*$@')));
-$response_type = filter_input(INPUT_GET, 'response_type', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '@^(id|code)$@')));
-$scope = filter_input(INPUT_GET, 'scope', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '@^[\x21\x23-\x5B\x5D-\x7E]*$@')));
+$me = filter_input(INPUT_GET, 'me', FILTER_VALIDATE_URL);
+$client_id = filter_input(INPUT_GET, 'client_id', FILTER_VALIDATE_URL);
+$redirect_uri = filter_input(INPUT_GET, 'redirect_uri', FILTER_VALIDATE_URL);
+$state = filter_input_regexp(INPUT_GET, 'state', '@^[\x20-\x7E]*$@');
+$response_type = filter_input_regexp(INPUT_GET, 'response_type', '@^(id|code)$@');
+$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]*$@');
 
 if (!is_string($me)) { // me is either omitted or not a valid URL.
-    error_page('Faulty Request', 'There was an error with the request. The "me" field is invalid.');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "me" field is invalid.'
+    );
 }
 if (!is_string($client_id)) { // client_id is either omitted or not a valid URL.
-    error_page('Faulty Request', 'There was an error with the request. The "client_id" field is invalid.');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "client_id" field is invalid.'
+    );
 }
 if (!is_string($redirect_uri)) { // redirect_uri is either omitted or not a valid URL.
-    error_page('Faulty Request', 'There was an error with the request. The "redirect_uri" field is invalid.');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "redirect_uri" field is invalid.'
+    );
 }
 if ($state === false) { // state contains invalid characters.
-    error_page('Faulty Request', 'There was an error with the request. The "state" field contains invalid data.');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "state" field contains invalid data.'
+    );
 }
 if ($response_type === false) { // response_type is given as something other than id or code.
-    error_page('Faulty Request', 'There was an error with the request. The "response_type" field must be "id" or "code".');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "response_type" field must be "id" or "code".'
+    );
 }
 if ($scope === false) { // scope contains invalid characters.
-    error_page('Faulty Request', 'There was an error with the request. The "scope" field contains invalid data.');
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "scope" field contains invalid data.'
+    );
 }
 
 // If the user submitted a password, get ready to redirect back to the callback.
@@ -160,12 +211,14 @@ if ($scope === false) { // scope contains invalid characters.
 $pass_input = filter_input(INPUT_POST, 'password', FILTER_UNSAFE_RAW);
 
 if ($pass_input !== null) {
-
     $csrf_code = filter_input(INPUT_POST, '_csrf', FILTER_UNSAFE_RAW);
 
     // Exit if the CSRF does not verify.
     if ($csrf_code === null || !verify_signed_code(APP_KEY, $client_id . $redirect_uri . $state, $csrf_code)) {
-        error_page('Invalid csrf code', 'Usually this means you took too long to log in. Please try again.');
+        error_page(
+            'Invalid CSF Code',
+            'Usually this means you took too long to log in. Please try again.'
+        );
     }
 
     // Exit if the password does not verify.
@@ -176,16 +229,18 @@ if ($pass_input !== null) {
     $code = create_signed_code(APP_KEY, USER_URL . $redirect_uri . $client_id, 5 * 60, $scope);
 
     $final_redir = $redirect_uri;
-    if(strpos($redirect_uri, '?') === false){
+    if (strpos($redirect_uri, '?') === false) {
         $final_redir .= '?';
     } else {
         $final_redir .= '&';
     }
-    $final_redir .= http_build_query(array(
-        'code' => $code,
-        'state' => $state,
-        'me' => $me
-    ));
+    $final_redir .= http_build_query(
+        array(
+            'code' => $code,
+            'state' => $state,
+            'me' => $me
+        )
+    );
 
     // Redirect back.
     header('Location: ' . $final_redir, true, 302);
@@ -220,16 +275,19 @@ padding:20px;
         </style>
     </head>
     <body>
-    <h1>Authenticate</h1>
-    <div>You are attempting to login with client <pre><?php echo $client_id; ?></pre></div>
-    <div>It is requesting the following scopes <pre><?php echo htmlspecialchars($scope); ?></pre></div>
-    <div>After login you will be redirected to  <pre><?php echo $redirect_uri; ?></pre></div>
-
-    <form method="POST" action="">
-        <input type="hidden" name="_csrf" value="<?php echo $csrf_code; ?>" />
-        <div class="form-line"><label for="password">Password:</label> <input type="password" name="password" id="password" /></div>
-        <div class="form-line"><input class="submit" type="submit" name="submit" value="Submit" /></div>
-    </form>
-
+        <h1>Authenticate</h1>
+        <div>You are attempting to login with client <pre><?php echo $client_id; ?></pre></div>
+        <div>It is requesting the following scopes <pre><?php echo htmlspecialchars($scope); ?></pre></div>
+        <div>After login you will be redirected to  <pre><?php echo $redirect_uri; ?></pre></div>
+        <form method="POST" action="">
+            <input type="hidden" name="_csrf" value="<?php echo $csrf_code; ?>" />
+            <div class="form-line">
+                <label for="password">Password:</label>
+                <input type="password" name="password" id="password" />
+            </div>
+            <div class="form-line">
+                <input class="submit" type="submit" name="submit" value="Submit" />
+            </div>
+        </form>
     </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -171,7 +171,7 @@ $client_id = filter_input(INPUT_GET, 'client_id', FILTER_VALIDATE_URL);
 $redirect_uri = filter_input(INPUT_GET, 'redirect_uri', FILTER_VALIDATE_URL);
 $state = filter_input_regexp(INPUT_GET, 'state', '@^[\x20-\x7E]*$@');
 $response_type = filter_input_regexp(INPUT_GET, 'response_type', '@^(id|code)$@');
-$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]+$@');
+$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*$@');
 
 if (!is_string($me)) { // me is either omitted or not a valid URL.
     error_page(

--- a/index.php
+++ b/index.php
@@ -142,6 +142,14 @@ if ($code !== null) {
         error_page('Verification Failed', 'Given Code Was Invalid');
     }
 
+    $response = array('me' => USER_URL);
+
+    $code_parts = explode(':', $code, 3);
+
+    if ($code_parts[2] !== '') {
+        $response['scope'] = $code_parts[2];
+    }
+
     // Find the q value for application/json.
     $json = get_q_value('application/json', $_SERVER['HTTP_ACCEPT']);
 
@@ -157,10 +165,10 @@ if ($code !== null) {
         );
     } elseif ($json >= $form) {
         header('Content-Type: application/json');
-        exit(json_encode(array('me' => USER_URL)));
+        exit(json_encode($response));
     } else {
         header('Content-Type: application/x-www-form-urlencoded');
-        exit(http_build_query(array('me' => USER_URL)));
+        exit(http_build_query($response));
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -301,9 +301,9 @@ padding:20px;
     </head>
     <body>
         <h1>Authenticate</h1>
-        <div>You are attempting to login with client <pre><?php echo $client_id; ?></pre></div>
+        <div>You are attempting to login with client <pre><?php echo htmlspecialchars($client_id); ?></pre></div>
         <div>It is requesting the following scopes <pre><?php echo htmlspecialchars($scope); ?></pre></div>
-        <div>After login you will be redirected to  <pre><?php echo $redirect_uri; ?></pre></div>
+        <div>After login you will be redirected to  <pre><?php echo htmlspecialchars($redirect_uri); ?></pre></div>
         <form method="POST" action="">
             <input type="hidden" name="_csrf" value="<?php echo $csrf_code; ?>" />
             <div class="form-line">

--- a/index.php
+++ b/index.php
@@ -171,7 +171,7 @@ $client_id = filter_input(INPUT_GET, 'client_id', FILTER_VALIDATE_URL);
 $redirect_uri = filter_input(INPUT_GET, 'redirect_uri', FILTER_VALIDATE_URL);
 $state = filter_input_regexp(INPUT_GET, 'state', '@^[\x20-\x7E]*$@');
 $response_type = filter_input_regexp(INPUT_GET, 'response_type', '@^(id|code)$@');
-$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]*$@');
+$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]+$@');
 
 if (!is_string($me)) { // me is either omitted or not a valid URL.
     error_page(
@@ -207,6 +207,18 @@ if ($scope === false) { // scope contains invalid characters.
     error_page(
         'Faulty Request',
         'There was an error with the request. The "scope" field contains invalid data.'
+    );
+}
+if ($response_type !== 'code' & $scope !== null) { // scope defined on identification request.
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "scope" field cannot be used with identification.'
+    );
+}
+if ($response_type === 'code' & $scope === null) { // scope omitted on code request.
+    error_page(
+        'Faulty Request',
+        'There was an error with the request. The "scope" field must be used with code requests.'
     );
 }
 

--- a/index.php
+++ b/index.php
@@ -209,13 +209,13 @@ if ($scope === false) { // scope contains invalid characters.
         'There was an error with the request. The "scope" field contains invalid data.'
     );
 }
-if ($response_type !== 'code' & $scope !== null) { // scope defined on identification request.
+if ($response_type !== 'code' && $scope !== null) { // scope defined on identification request.
     error_page(
         'Faulty Request',
         'There was an error with the request. The "scope" field cannot be used with identification.'
     );
 }
-if ($response_type === 'code' & $scope === null) { // scope omitted on code request.
+if ($response_type === 'code' && $scope === null) { // scope omitted on code request.
     error_page(
         'Faulty Request',
         'There was an error with the request. The "scope" field must be used with code requests.'

--- a/index.php
+++ b/index.php
@@ -178,8 +178,8 @@ $me = filter_input(INPUT_GET, 'me', FILTER_VALIDATE_URL);
 $client_id = filter_input(INPUT_GET, 'client_id', FILTER_VALIDATE_URL);
 $redirect_uri = filter_input(INPUT_GET, 'redirect_uri', FILTER_VALIDATE_URL);
 $state = filter_input_regexp(INPUT_GET, 'state', '@^[\x20-\x7E]*$@');
-$response_type = filter_input_regexp(INPUT_GET, 'response_type', '@^(id|code)$@');
-$scope = filter_input_regexp(INPUT_GET, 'scope', '@^[\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*$@');
+$response_type = filter_input_regexp(INPUT_GET, 'response_type', '@^(id|code)?$@');
+$scope = filter_input_regexp(INPUT_GET, 'scope', '@^([\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*)?$@');
 
 if (!is_string($me)) { // me is either omitted or not a valid URL.
     error_page(
@@ -216,6 +216,14 @@ if ($scope === false) { // scope contains invalid characters.
         'Faulty Request',
         'There was an error with the request. The "scope" field contains invalid data.'
     );
+}
+if ($scope === '') { // scope is left empty.
+    // Treat empty parameters as if omitted.
+    $scope = null;
+}
+if ($response_type === null || $response_type === '') { // response_type is omitted or left empty.
+    // For omitted or left empty, use the default response_type.
+    $response_type = 'id';
 }
 if ($response_type !== 'code' && $scope !== null) { // scope defined on identification request.
     error_page(

--- a/setup.php
+++ b/setup.php
@@ -24,22 +24,24 @@ padding:20px;
 <body>
 <h1>Setup Selfauth</h1>
 <div class="instructions">In order to configure Selfauth, you need to fill in a few values, this page helps generate those options.</div>
-<?php if(isset($_POST['username'])):?>
+<?php if (isset($_POST['username'])) : ?>
 <div>
-<?php define('RANDOM_BYTE_COUNT', 32);
+<?php
+define('RANDOM_BYTE_COUNT', 32);
 
-    $app_url = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] 
+    $app_url = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HTTP_HOST']
       . str_replace('setup.php', '', $_SERVER['REQUEST_URI']);
 
-    if(function_exists('random_bytes')) {
-        $bytes = random_bytes(RANDOM_BYTE_COUNT);
-    } elseif(function_exists('openssl_random_pseudo_bytes')){
-        $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT);
-    } else {
-        for ($i=0, $bytes=''; $i < RANDOM_BYTE_COUNT; $i++) {
-            $bytes .= chr(mt_rand(0, 255));
-        }
+if (function_exists('random_bytes')) {
+    $bytes = random_bytes(RANDOM_BYTE_COUNT);
+} elseif (function_exists('openssl_random_pseudo_bytes')) {
+    $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT);
+} else {
+    $bytes = '';
+    for ($i=0; $i < RANDOM_BYTE_COUNT; $i++) {
+        $bytes .= chr(mt_rand(0, 255));
     }
+}
     $app_key = bin2hex($bytes);
 
 
@@ -60,48 +62,45 @@ define('USER_URL', '$user');";
 
     $configured = true;
 
-    if(file_exists($configfile)){
+if (file_exists($configfile)) {
+    require_once $configfile;
 
-        require_once $configfile;
-        
-        if((!defined('APP_URL') || APP_URL == '')
-            || (!defined('APP_KEY') || APP_KEY == '')
-            || (!defined('USER_HASH') || USER_HASH == '')
-            || (!defined('USER_URL') || USER_URL == '')
-        ) {
-            $configured = false;
-        }
-    } else {
+    if ((!defined('APP_URL') || APP_URL == '')
+    || (!defined('APP_KEY') || APP_KEY == '')
+    || (!defined('USER_HASH') || USER_HASH == '')
+    || (!defined('USER_URL') || USER_URL == '')
+    ) {
         $configured = false;
     }
+} else {
+    $configured = false;
+}
 
-	$file_written = false;
+    $file_written = false;
 
-    if(is_writeable($configfile) && !$configured){
+if (is_writeable($configfile) && !$configured) {
+    $handle = fopen($configfile, 'w');
 
-		$handle = fopen($configfile, 'w');
-
-		if($handle){
-			$result = fwrite($handle, $config_file_contents);
-			if($result !== FALSE){
-				$file_written = true;
-			}
-			
-		}
-
-		fclose($handle);
+    if ($handle) {
+        $result = fwrite($handle, $config_file_contents);
+        if ($result !== false) {
+            $file_written = true;
+        }
     }
 
+    fclose($handle);
+}
 
-    if($file_written){
-		echo '<div class="message">config.php was successfully written to disk</div>';
-	} else {
-        echo '<div class="message">Fill in the file config.php with the following content</div>';
-        echo '<pre>';
-        echo htmlentities($config_file_contents);
-        echo '</pre>';
-    }
- ?>
+
+if ($file_written) {
+    echo '<div class="message">config.php was successfully written to disk</div>';
+} else {
+    echo '<div class="message">Fill in the file config.php with the following content</div>';
+    echo '<pre>';
+    echo htmlentities($config_file_contents);
+    echo '</pre>';
+}
+    ?>
 </div>
 <?php endif ?>
 <form method="POST" action="">


### PR DESCRIPTION
Welcome to a slightly-bigger-PR.

## Input data validation

Everything is taken from either the query string (`$_GET`) or post body (`$_POST`) through PHP’s `filter_input`. The super-globals are never accessed directly.

`me`, `client_id`, and `redirect_uri` are always validated with `FILTER_VALIDATE_URL`. Since PHP 5.2.1 this automatically means it expects a valid scheme and host. Others get their own regular expressions.

Currently an error is thrown if `response_type` is not `id`, `code`, or omitted. But non of those values have any effect on the authorisation code that will be generated. This means a `scope` can be included even on identification requests. In short: Selfauth does not care about the type. if you supply your password for whatever a client asks for, it will sign it.

Some questions that should be addressed before merging:

1. What to do if a `scope` is defined on an identification (`response_type` set to `id` or omitted) request?
2. What to do if the `scope` is defined as an empty string? Is there such a thing as an empty scope on authorisation requests?

## Style guide

I have adapted the code to use shorter line-lengths and have overall the same whitespace rules. Thought this would be the right time to try and introduce a style guide as the reordering of checks touched a lot of lines of the code anyway.

I currently validate using:

```
phpcs --standard=PEAR,PSR1,PSR2 --exclude="PSR1.Files.SideEffects,PEAR.NamingConventions.ValidFunctionName,PEAR.Commenting.FunctionComment,PEAR.Commenting.FileComment" index.php
```

Notes:

* I include PEAR for their slightly stricter validation of breaking up IF statements and the like. Personal preference, feel free to be annoyed by it.
* We have to exclude `PSR1.Files.SideEffects` because we define functions within this file.
* There is still one line that does not validate, line 125, but I don’t feel like breaking up that string gets us anywhere.

## Content negotiation

I took this out into its own function, but I am not happy about the name of the function yet. Very little tweaking otherwise, apart from making the regular expression more general. We can now easily start negotiating for other Content-Types if necessary.

The regular expression is also still a bit of a pain. But that can be its own future issue.