### PR TITLE
Clean up setup.php, fixing warnings

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -24,7 +24,6 @@ padding:20px;
 </head>
 <body>
 <h1>Setup Selfauth</h1>
-<div class="instructions">In order to configure Selfauth, you need to fill in a few values, this page helps generate those options.</div>
 <div>
 <?php
 define('RANDOM_BYTE_COUNT', 32);
@@ -34,29 +33,17 @@ $app_url = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HT
 
 if (function_exists('random_bytes')) {
     $bytes = random_bytes(RANDOM_BYTE_COUNT);
+    $strong_crypto = true;
 } elseif (function_exists('openssl_random_pseudo_bytes')) {
-    $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT);
+    $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT, $strong_crypto);
 } else {
     $bytes = '';
     for ($i=0; $i < RANDOM_BYTE_COUNT; $i++) {
         $bytes .= chr(mt_rand(0, 255));
     }
+    $strong_crypto = false;
 }
 $app_key = bin2hex($bytes);
-
-
-$user = $_POST['username'];
-
-$user_tmp = trim(preg_replace('/^https?:\/\//', '', $_POST['username']), '/');
-$pass = md5($user_tmp . $_POST['password'] . $app_key);
-
-$config_file_contents = "<?php
-define('APP_URL', '$app_url');
-define('APP_KEY', '$app_key');
-define('USER_HASH', '$pass');
-define('USER_URL', '$user');";
-
-
 
 $configfile= __DIR__ . '/config.php';
 
@@ -82,20 +69,8 @@ if ($configured) : ?>
         If you with to reconfigure, please remove config.php and reload this page.
     </div>
 
-<?php
-else :
-    define('RANDOM_BYTE_COUNT', 32);
-
-    $strong_crypto = true;
-
-    if (!function_exists('random_bytes') || !function_exists('openssl_random_pseudo_bytes') || !function_exists('hash_equals')) {
-        $strong_crypto = false;
-    } else {
-        $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT, $strong_crypto);
-    }
-
-?>
-    <?php if ($strong_crypto) : ?>
+<?php else : ?>
+    <?php if ($strong_crypto === false) : ?>
         <h2>
            WARNING: this version of PHP does not support functions 'random_bytes' or 'openssl_random_pseudo_bytes'. 
            This means your application is not as secure as it could be.  You may continues, but it is strongly recommended you upgrade PHP.
@@ -107,20 +82,6 @@ else :
     <div>
     <?php
     $app_url = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . str_replace('setup.php', '', $_SERVER['REQUEST_URI']);
-
-    if (function_exists('random_bytes')) {
-        $bytes = random_bytes(RANDOM_BYTE_COUNT);
-    } elseif (function_exists('openssl_random_pseudo_bytes')) {
-        $bytes = openssl_random_pseudo_bytes(RANDOM_BYTE_COUNT);
-    } else {
-        $bytes = '';
-        for ($i=0; $i < RANDOM_BYTE_COUNT; $i++) {
-            $bytes .= chr(mt_rand(0, 255));
-        }
-    }
-
-    $app_key = bin2hex($bytes);
-
 
     $user = $_POST['username'];
 


### PR DESCRIPTION
Apparently https://github.com/Inklings-io/selfauth/commit/d299becf4c1d798d1eddaf812b1448813ac7a28e broke stuff. Especially by removing the first `isset()` check for `$_POST`. This lead to a lot of warnings on my screen when I tried to set selfauth up on a clean environment.

It also warned me my set-up was insecure. (PHP 7.1? Really?) I fixed this by making it more obvious how we set `$strong_crypto` and how it is checked.

This PR tries to make the set-up work again, nothing else. Most of this was fixable by removing code that was duplicated. Remove the code where it shouldn’t be, keep it where it should be, and then it all works again.

Please checkout this branch and try the set-up as part of the review. Would like to get it right this time.