### PR TITLE
Remove checks based on response_type

### DIFF
--- a/index.php
+++ b/index.php
@@ -236,7 +236,7 @@ if ($state === false) { // state contains invalid characters.
 if ($response_type === false) { // response_type is given as something other than id or code.
     error_page(
         'Faulty Request',
-        'There was an error with the request. The "response_type" field must be "id" or "code".'
+        'There was an error with the request. The "response_type" field must be "code".'
     );
 }
 if ($scope === false) { // scope contains invalid characters.
@@ -248,22 +248,6 @@ if ($scope === false) { // scope contains invalid characters.
 if ($scope === '') { // scope is left empty.
     // Treat empty parameters as if omitted.
     $scope = null;
-}
-if ($response_type === null || $response_type === '') { // response_type is omitted or left empty.
-    // For omitted or left empty, use the default response_type.
-    $response_type = 'id';
-}
-if ($response_type !== 'code' && $scope !== null) { // scope defined on identification request.
-    error_page(
-        'Faulty Request',
-        'There was an error with the request. The "scope" field cannot be used with identification.'
-    );
-}
-if ($response_type === 'code' && $scope === null) { // scope omitted on code request.
-    error_page(
-        'Faulty Request',
-        'There was an error with the request. The "scope" field must be used with code requests.'
-    );
 }
 
 // If the user submitted a password, get ready to redirect back to the callback.


### PR DESCRIPTION
IndieAuth has always had some weird handling of `response_type`. All responses were always of OAuth type `code`, but the standard defined its own type `id` as well as making the field optional.

In the latest version of the IndieAuth standard, these decisions have been revised in favour of sticking to OAuth’s more standard handling. IndieAuth only accepts `response_type=code`. See indieweb/indieauth#42.

For backwards compatibility, this change still accept both `code` and `id`, as well as an empty value. All checks about differences between `code` and `id` have been removed as it should all just be handled as if a client had used the value `code`.