### PR TITLE
support discovery by issuer

### DIFF
--- a/index.php
+++ b/index.php
@@ -309,7 +309,7 @@ if ($pass_input !== null) {
     } else {
         $final_redir .= '&';
     }
-    $issuer = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_NAME'];
+    $issuer = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HTTP_HOST'];
     $parameters = array(
         'code' => $code,
         'iss' => $issuer,

--- a/index.php
+++ b/index.php
@@ -309,8 +309,10 @@ if ($pass_input !== null) {
     } else {
         $final_redir .= '&';
     }
+    $issuer = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_NAME'];
     $parameters = array(
         'code' => $code,
+        'iss' => $issuer,
         'me' => USER_URL
     );
     if ($state !== null) {


### PR DESCRIPTION
When IndieAuth\Client (https://github.com/indieweb/indieauth-client-php) discovers SelfAuth through a metadata endpoint, it requires that the issuer is returned. This is expected to be the same as the metadata.